### PR TITLE
Update PR, additional checks, and fix syntax issue in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-dist: xenial
+os: linux
+dist: bionic
+language: python
 
 services:
   - docker
   - mongodb
 
-language: python
 install:
   - pip install tox
   - pip install tox-travis
@@ -13,9 +14,12 @@ script:
   - tox
 
 jobs:
+  allow_failures:
+    - python: 3.9-dev
   include:
     - python: 3.6
     - python: 3.7
+    - python: 3.8
     - python: pypy3
 
     - stage: Deploy new release

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,4 @@
 pyop
 Flask
 gunicorn
+oic>=1.2.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email='satosa-dev@lists.sunet.se',
     description='OpenID Connect Provider (OP) library in Python.',
     install_requires=[
-        'oic >= 0.15.0',
+        'oic >= 1.2.1',
         'pymongo'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ setup(
     author_email='satosa-dev@lists.sunet.se',
     description='OpenID Connect Provider (OP) library in Python.',
     install_requires=[
-        'oic >= 0.15.0',
+        'oic >= 0.15.0'
+    ]
+    extras_require=[
         'pymongo',
         'redis'
     ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyop',
-    version='3.1.0',
+    version='3.1.1',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     url='https://github.com/IdentityPython/pyop',

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(
     description='OpenID Connect Provider (OP) library in Python.',
     install_requires=[
         'oic >= 0.15.0'
-    ]
-    extras_require=[
-        'pymongo',
-        'redis'
-    ]
+    ],
+    extras_require={
+        'mongo': 'pymongo',
+        'redis': 'redis'
+    }
 )

--- a/src/pyop/authz_state.py
+++ b/src/pyop/authz_state.py
@@ -59,25 +59,25 @@ class AuthorizationState(object):
         """
         Mapping of authorization codes to the subject identifier and auth request.
         """
-        self.authorization_codes = authorization_code_db or {}
+        self.authorization_codes = authorization_code_db if authorization_code_db is not None else {}
 
         self.access_token_lifetime = access_token_lifetime
         """
         Mapping of access tokens to the scope, token type, client id and subject identifier.
         """
-        self.access_tokens = access_token_db or {}
+        self.access_tokens = access_token_db if access_token_db is not None else {}
 
         self.refresh_token_lifetime = refresh_token_lifetime
         self.refresh_token_threshold = refresh_token_threshold
         """
         Mapping of refresh tokens to access tokens.
         """
-        self.refresh_tokens = refresh_token_db or {}
+        self.refresh_tokens = refresh_token_db if refresh_token_db is not None else {}
 
         """
         Mapping of user id's to subject identifiers.
         """
-        self.subject_identifiers = subject_identifier_db or {}
+        self.subject_identifiers = subject_identifier_db if subject_identifier_db is not None else {}
 
     def create_authorization_code(self, authorization_request, subject_identifier, scope=None):
         # type: (oic.oic.message.AuthorizationRequest, str, Optional[List[str]]) -> str

--- a/src/pyop/client_authentication.py
+++ b/src/pyop/client_authentication.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+from urllib.parse import unquote
 
 from .exceptions import InvalidClientAuthentication
 
@@ -35,7 +36,7 @@ def verify_client_authentication(clients, parsed_request, authz_header=None):
                 auth = base64.urlsafe_b64decode(credentials.encode('utf-8')).decode('utf-8')
             except UnicodeDecodeError as e:
                 raise InvalidClientAuthentication('Could not userid/password from authorization header'.format(authz_scheme))
-            client_id, client_secret = auth.split(':')
+            client_id, client_secret = [unquote(part) for part in auth.split(':')]
         else:
             raise InvalidClientAuthentication('Unknown scheme in authorization header, {} != Basic'.format(authz_scheme))
     elif 'client_id' in parsed_request:

--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -160,7 +160,7 @@ class RedisWrapper(StorageBase):
 
     def items(self):
         for key in self._db.keys(self._collection + "*"):
-            visible_key = key[len(self._collection) + 1 :]
+            visible_key = key[len(self._collection) + 1 :].decode()
             try:
                 yield (visible_key, self[visible_key])
             except KeyError:

--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -5,7 +5,7 @@ import copy
 import json
 import pymongo
 from redis.client import Redis
-from time import time
+from datetime import datetime
 
 
 class StorageBase(ABC):
@@ -54,18 +54,29 @@ class StorageBase(ABC):
 
 
 class MongoWrapper(StorageBase):
-    def __init__(self, db_uri, db_name, collection):
+    def __init__(self, db_uri, db_name, collection, ttl=None):
         self._db_uri = db_uri
         self._coll_name = collection
         self._db = MongoDB(db_uri, db_name=db_name)
         self._coll = self._db.get_collection(collection)
         self._coll.create_index('lookup_key', unique=True)
 
+        if ttl is None or (isinstance(ttl, int) and ttl >= 0):
+            self._ttl = ttl
+        else:
+            raise ValueError("TTL must be a non-negative integer or None")
+        if ttl is not None:
+            self._coll.create_index(
+                'last_modified',
+                expireAfterSeconds=ttl,
+                name="expiry"
+            )
+
     def __setitem__(self, key, value):
         doc = {
             'lookup_key': key,
             'data': value,
-            'modified_ts': time()
+            'last_modified': datetime.utcnow()
         }
         self._coll.replace_one({'lookup_key': key}, doc, upsert=True)
 
@@ -143,14 +154,17 @@ class MongoDB(object):
         if db_uri is None:
             raise ValueError('db_uri not supplied')
 
-        self._db_uri = db_uri
-        self._database_name = db_name
         self._sanitized_uri = None
 
         self._parsed_uri = pymongo.uri_parser.parse_uri(db_uri)
 
         if self._parsed_uri.get('database') is None:
+            if db_name is None:
+                raise ValueError(
+                    "Database name must be provided either in the URI or as an argument"
+                )
             self._parsed_uri['database'] = db_name
+        self._database_name = self._parsed_uri['database']
 
         if 'replicaSet' in kwargs and kwargs['replicaSet'] is None:
             del kwargs['replicaSet']

--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -160,7 +160,11 @@ class RedisWrapper(StorageBase):
 
     def items(self):
         for key in self._db.keys(self._collection + "*"):
-            visible_key = key[len(self._collection) + 1 :].decode()
+            visible_key = key[len(self._collection) + 1 :]
+
+            if isinstance(visible_key, bytes):
+                visible_key = visible_key.decode()
+
             try:
                 yield (visible_key, self[visible_key])
             except KeyError:

--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -120,10 +120,15 @@ class RedisWrapper(StorageBase):
     Supports JSON-serializable data types.
     """
 
-    def __init__(self, db_uri, collection, ttl=None):
+    def __init__(self, collection, db_uri=None, redis=Redis(), ttl=None):
         self.ensure_dependency(["redis.client"])
-        self._db = Redis.from_url(db_uri, decode_responses=True)
         self._collection = collection
+
+        if db_uri is not None:
+            self._db = Redis.from_url(db_uri, decode_responses=True)
+        else:
+            self._db = redis
+
         if ttl is None or (isinstance(ttl, int) and ttl >= 0):
             self._ttl = ttl
         else:

--- a/tests/pyop/test_storage.py
+++ b/tests/pyop/test_storage.py
@@ -168,3 +168,15 @@ class TestRedisTTL(StorageTTLTest):
 
     def test_ttl(self):
         self.execute_ttl_test("redis://localhost/0", 3600)
+
+
+class TestMongoTTL(StorageTTLTest):
+    def set_time(self, offset, monkeypatch):
+        now = datetime.datetime.utcnow()
+        def new_time():
+            return now + datetime.timedelta(seconds=offset)
+
+        monkeypatch.setattr(mongomock, "utcnow", new_time)
+
+    def test_ttl(self):
+        self.execute_ttl_test("mongodb://localhost/pyop", 3600)

--- a/tests/pyop/test_storage.py
+++ b/tests/pyop/test_storage.py
@@ -10,6 +10,7 @@ import fakeredis
 import mongomock
 import pymongo
 import time
+import sys
 
 from pyop.storage import StorageBase
 
@@ -169,6 +170,12 @@ class TestRedisTTL(StorageTTLTest):
     def test_ttl(self):
         self.execute_ttl_test("redis://localhost/0", 3600)
 
+    def test_missing_module(self):
+        sys.modules.pop("redis.client")
+        with pytest.raises(ImportError):
+            self.prepare_db("redis://localhost/0", None)
+        from redis.client import Redis
+
 
 class TestMongoTTL(StorageTTLTest):
     def set_time(self, offset, monkeypatch):
@@ -180,3 +187,9 @@ class TestMongoTTL(StorageTTLTest):
 
     def test_ttl(self):
         self.execute_ttl_test("mongodb://localhost/pyop", 3600)
+
+    def test_missing_module(self):
+        sys.modules.pop("pymongo")
+        with pytest.raises(ImportError):
+            self.prepare_db("mongodb://localhost/0", None)
+        import pymongo

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -4,3 +4,5 @@ responses
 pycryptodomex
 fakeredis
 mongomock
+pymongo
+redis


### PR DESCRIPTION
This pull requests has three changes:
- merge with latest master branch of pyop
- fix the extra requires in setup.py, allowing `pip install pyop[redis]` or `pip install pyop[mongo]` or no extras.
- adds an additional check in pyop.storage.RedisWrapper().items(), ensuring that we are returning strings and not bytes. See commit message: 

    "The return type of the _db.keys() is List[_StrType], where _StrType is a str or bytes. As we want the items() method to return strings (given the provided __getitem__ method) for keys we need an additional check."